### PR TITLE
[fixed] Fix windows file naming errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ columns = "0.1.0"
 colored = "2.0.4"
 anyhow = "1.0.75"
 url = "2.4.1"
+regex = "1.4"
 
 [profile.dev]
 opt-level = 0

--- a/src/cli/screenshot.rs
+++ b/src/cli/screenshot.rs
@@ -144,7 +144,7 @@ async fn take_screenshot(
         .http1_ignore_invalid_headers_in_responses(true)
         .trust_dns(true)
         .build()?;
-    let re = Regex::new(r"[<>?.~!@#$%^&*\/|;:']").unwrap();
+    let re = Regex::new(r"[<>?.~!@#$%^&*\\/|;:']").unwrap();
     let regurl = re.replace_all(&url, "").to_string();
 
     let filename = format!(

--- a/src/cli/screenshot.rs
+++ b/src/cli/screenshot.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 use std::{env, path::Path, time::Duration};
 use tokio::{fs, task, time};
 use url::Url;
+use regex::Regex;
 
 pub async fn run(
     Cli {
@@ -143,11 +144,14 @@ async fn take_screenshot(
         .http1_ignore_invalid_headers_in_responses(true)
         .trust_dns(true)
         .build()?;
+    let re = Regex::new(r"[<>?.~!@#$%^&*\/|;:']").unwrap();
+    let regurl = re.replace_all(&url, "").to_string();
 
     let filename = format!(
         "{}.png",
-        url.replace("://", "-").replace('/', "_").replace(':', "-")
+        regurl.replace("://", "-").replace('/', "_").replace(':', "-")
     );
+    
     let page = browser.new_page(parsed_url.clone()).await?;
     page.save_screenshot(
         ScreenshotParams::builder()


### PR DESCRIPTION
Fix windows file naming errors https://github.com/pwnwriter/haylxon/issues/36
在Windows中，以下字符是特殊命名的，不能用于文件名或目录名：
```
<（小于号）
>（大于号）
:（冒号）
"（双引号）
/（正斜杠）
\（反斜杠）
|（管道符号）
?（问号）
*（星号）
```