### PR TITLE
feat(args): run arbitary javascript in websites

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -76,6 +76,10 @@ pub struct Cli {
     /// Accept invalid certs, trust dns
     #[arg(long)]
     pub accept_invalid_certs: bool,
+
+    /// Run arbiraty javascript
+    #[arg(long)]
+    pub javascript: Option<String>,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -29,6 +29,7 @@ pub async fn run(
         screenshot_type,
         ports,
         accept_invalid_certs,
+        javascript,
     }: Cli,
 ) -> anyhow::Result<()> {
     let browser = Path::new(&binary_path);
@@ -105,6 +106,7 @@ pub async fn run(
             fullpage,
             screenshot_type,
             accept_invalid_certs,
+            javascript,
         )
         .await?;
     } else {
@@ -122,6 +124,7 @@ pub async fn run(
                     fullpage,
                     screenshot_type,
                     accept_invalid_certs,
+                    javascript,
                 )
                 .await?;
             }
@@ -142,6 +145,7 @@ pub async fn run(
                     fullpage,
                     screenshot_type,
                     accept_invalid_certs,
+                    javascript,
                 )
                 .await?;
             }


### PR DESCRIPTION
This pr will be adding a new argument to run arbitary javascript. 

One can invoke it using `--javascript <js code>` . 